### PR TITLE
Use IANA compliant charset

### DIFF
--- a/src/CountryRepository.php
+++ b/src/CountryRepository.php
@@ -2933,7 +2933,7 @@ class CountryRepository
             }
 
             foreach ($names as $name) {
-                if ($value === mb_strtolower($name) || $value === mb_strtolower(iconv('utf8', 'ASCII//TRANSLIT', $name))) {
+                if ($value === mb_strtolower($name) || $value === mb_strtolower(iconv('UTF-8', 'ASCII//TRANSLIT', $name))) {
                     return $this->findByIsoAlpha2($code);
                 }
             }


### PR DESCRIPTION
`utf8` is not a [IANA compliant character set](https://www.iana.org/assignments/character-sets/character-sets.xhtml). The correct charset is `UTF-8`.
This is an issue for `iconv` on Alpine Linux.